### PR TITLE
Update primer utilities dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![NPM version](http://img.shields.io/npm/v/stylelint-selector-no-utility.svg)](https://www.npmjs.org/package/stylelint-selector-no-utility)
 [![Build Status](https://travis-ci.org/primer/stylelint-selector-no-utility.svg?branch=master)](https://travis-ci.org/primer/stylelint-selector-no-utility)
 
-**This plugin is extra specific to [primer-utilities](https://github.com/primer/utilities)** I will accept PRs to make it more generic, or feel free to fork and use it for your own classes.
+**This plugin is specific to [primer-utilities](https://github.com/primer/primer-css/modules/utilities)**. We'll accept pull requests to make it more generic, or feel free to fork and use it for your own classes.
 
-You should not be able to style a utility classes. Utility classes are single purpose, reusing them to add extra style violates their single purpose.
+Utilities are single purpose styles that should be treated as immutable CSS. They should not be altered by custom CSS as this can cause unwanted side effects.
 
 ```css
     .m-0, #bar .float-left, #hoo { border: 1px solid pink; }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NPM version](http://img.shields.io/npm/v/stylelint-selector-no-utility.svg)](https://www.npmjs.org/package/stylelint-selector-no-utility)
 [![Build Status](https://travis-ci.org/primer/stylelint-selector-no-utility.svg?branch=master)](https://travis-ci.org/primer/stylelint-selector-no-utility)
 
-**This plugin is specific to [primer-utilities](https://github.com/primer/primer-css/modules/utilities)**. We'll accept pull requests to make it more generic, or feel free to fork and use it for your own classes.
+**This plugin is specific to [primer-utilities](https://github.com/primer/primer-css/tree/master/modules/primer-utilities)**. We'll accept pull requests to make it more generic, or feel free to fork and use it for your own classes.
 
 Utilities are single purpose styles that should be treated as immutable CSS. They should not be altered by custom CSS as this can cause unwanted side effects.
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/primer/stylelint-selector-no-utility#readme",
   "dependencies": {
-    "primer-utilities": "^3.0.0",
+    "primer-utilities": "^4.3.5",
     "stylelint": "^7.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-selector-no-utility",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Stylelint rule that doesn't allow the styling of utility classes in CSS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When updating the GitHub app to use the latest version of Primer I noticed that it was pulling in two versions of Primer utilities since it's a dependency for this plugin. We've added a bunch more utilities so seems worth bumping this now.

This pr:
- updates utilities dependency to latest version of `primer-utilities`
- updates url path for utilities package
- improves wording on readme

cc @primer/ds-core 